### PR TITLE
reformat tables and cells, add brighton high stripe info

### DIFF
--- a/src/components/RegisterPage/RegisterPage.js
+++ b/src/components/RegisterPage/RegisterPage.js
@@ -41,7 +41,7 @@ class RegisterPage extends Component {
                 <h3>
                     Registration
                 </h3>
-                <table>
+                <table style={styles.table}>
                     <tr>
                         <td style={styles.table_description}>Alumni Only </td>
                         <td style={styles.table_cost}>$104</td>
@@ -57,7 +57,7 @@ class RegisterPage extends Component {
                 <h3>
                     Day Of Registration
                 </h3>
-                <table>
+                <table style={styles.table}>
                     <tr>
                         <td style={styles.table_description}>Day Of - Alumni Only </td>
                         <td style={styles.table_cost}>$120</td>

--- a/src/components/RegisterPage/RegisterPage.js
+++ b/src/components/RegisterPage/RegisterPage.js
@@ -12,6 +12,7 @@ import '../../styles/common.css';
 
 class RegisterPage extends Component {
     render() {
+        const styles = this.styles()
         return (
             <div className="details-container">
               <div className="details-left">
@@ -20,6 +21,54 @@ class RegisterPage extends Component {
                 <h3 className="details-left-medium">Registration is $104 after August 1st, and $120 the day of the event (October 14).</h3>
                 {/* spacing */}
                 <br />
+
+                <h3>
+                    Early Registration
+                </h3>
+                <table style={styles.table}>
+                    <tr>
+                        <td style={styles.table_description}>Alumni Only </td>
+                        <td style={styles.table_cost}>$94</td>
+                        <td style={styles.table_button}><StripeAlumniPre /></td>
+                    </tr>
+                    <tr>
+                        <td style={styles.table_description}>Alumni + Spouse </td>
+                        <td style={styles.table_cost}>$157</td>
+                        <td style={styles.table_button}><StripeAlumniSpousePre /></td>
+                    </tr>
+                </table>
+                <br />
+                <h3>
+                    Registration
+                </h3>
+                <table>
+                    <tr>
+                        <td style={styles.table_description}>Alumni Only </td>
+                        <td style={styles.table_cost}>$104</td>
+                        <td style={styles.table_button}><StripeAlumni /></td>
+                    </tr>
+                    <tr>
+                        <td style={styles.table_description}>Alumni + Spouse </td>
+                        <td style={styles.table_cost}>$167</td>
+                        <td style={styles.table_button}><StripeAlumniSpouse /></td>
+                    </tr>
+                </table>
+                <br />
+                <h3>
+                    Day Of Registration
+                </h3>
+                <table>
+                    <tr>
+                        <td style={styles.table_description}>Day Of - Alumni Only </td>
+                        <td style={styles.table_cost}>$120</td>
+                        <td style={styles.table_button}><StripeAlumniDayOf /></td>
+                    </tr>
+                    <tr>
+                        <td style={styles.table_description}>Day Of - Alumni + Spouse </td>
+                        <td style={styles.table_cost}>$183</td>
+                        <td style={styles.table_button}><StripeAlumniSpouseDayOf /></td>
+                    </tr>
+                </table>
 
                 <h5>Why so expensive?</h5>
 
@@ -49,54 +98,26 @@ class RegisterPage extends Component {
             </div>
             <div className="details-right flex-column column-spread">
                 <img className="logo no-margin" src={logo} alt="Brighton Bengals"/>
-                <h3>
-                    Early Registration
-                </h3>
-                <table>
-                    <tr>
-                        <td>Alumni Only </td>
-                        <td>$94</td>
-                        <td><StripeAlumniPre /></td>
-                    </tr>
-                    <tr>
-                        <td>Alumni + Spouse </td>
-                        <td>$157</td>
-                        <td><StripeAlumniSpousePre /></td>
-                    </tr>
-                </table>
-                <h3>
-                    Registration
-                </h3>
-                <table>
-                    <tr>
-                        <td>Alumni Only </td>
-                        <td>$104</td>
-                        <td><StripeAlumni /></td>
-                    </tr>
-                    <tr>
-                        <td>Alumni + Spouse </td>
-                        <td>$167</td>
-                        <td><StripeAlumniSpouse /></td>
-                    </tr>
-                </table>
-                <h3>
-                    Day Of Registration
-                </h3>
-                <table>
-                    <tr>
-                        <td>Day Of - Alumni Only </td>
-                        <td>$120</td>
-                        <td><StripeAlumniDayOf /></td>
-                    </tr>
-                    <tr>
-                        <td>Day Of - Alumni + Spouse </td>
-                        <td>$183</td>
-                        <td><StripeAlumniSpouseDayOf /></td>
-                    </tr>
-                </table>
             </div>
         </div>
         );
+    }
+
+    styles () {
+        return {
+            table: {
+                margin: 10
+            },
+            table_description: {
+                width: 200
+            },
+            table_cost: {
+                width: 75
+            },
+            table_button: {
+                width: 150
+            }
+        }
     }
 }
 

--- a/src/components/Stripe/StripeAlumni.js
+++ b/src/components/Stripe/StripeAlumni.js
@@ -22,7 +22,7 @@ class StripeAlumni extends Component {
           panelLabel="Register"
           amount={10400}
           currency="USD"
-          stripeKey="pk_test_yFliojp5k9U6cxv0NRVL3W9U"
+          stripeKey="pk_test_mjnzkL9ebrh2Zbb5vy8hzniN"
           shippingAddress
           billingAddress={false}
           zipCode={false}

--- a/src/components/Stripe/StripeAlumniDayOf.js
+++ b/src/components/Stripe/StripeAlumniDayOf.js
@@ -22,7 +22,7 @@ class StripeAlumniDayOf extends Component {
           panelLabel="Register"
           amount={12000}
           currency="USD"
-          stripeKey="pk_test_yFliojp5k9U6cxv0NRVL3W9U"
+          stripeKey="pk_test_mjnzkL9ebrh2Zbb5vy8hzniN"
           shippingAddress
           billingAddress={false}
           zipCode={false}

--- a/src/components/Stripe/StripeAlumniPre.js
+++ b/src/components/Stripe/StripeAlumniPre.js
@@ -22,7 +22,7 @@ class StripeAlumniPre extends Component {
           panelLabel="Register"
           amount={9400}
           currency="USD"
-          stripeKey="pk_test_yFliojp5k9U6cxv0NRVL3W9U"
+          stripeKey="pk_test_mjnzkL9ebrh2Zbb5vy8hzniN"
           shippingAddress
           billingAddress={false}
           zipCode={false}

--- a/src/components/Stripe/StripeAlumniSpouse.js
+++ b/src/components/Stripe/StripeAlumniSpouse.js
@@ -22,7 +22,7 @@ class StripeAlumniSpouse extends Component {
           panelLabel="Register"
           amount={16700}
           currency="USD"
-          stripeKey="pk_test_yFliojp5k9U6cxv0NRVL3W9U"
+          stripeKey="pk_test_mjnzkL9ebrh2Zbb5vy8hzniN"
           shippingAddress
           billingAddress={false}
           zipCode={false}

--- a/src/components/Stripe/StripeAlumniSpouseDayOf.js
+++ b/src/components/Stripe/StripeAlumniSpouseDayOf.js
@@ -22,7 +22,7 @@ class StripeAlumniSpouseDayOf extends Component {
           panelLabel="Register"
           amount={18300}
           currency="USD"
-          stripeKey="pk_test_yFliojp5k9U6cxv0NRVL3W9U"
+          stripeKey="pk_test_mjnzkL9ebrh2Zbb5vy8hzniN"
           shippingAddress
           billingAddress={false}
           zipCode={false}

--- a/src/components/Stripe/StripeAlumniSpousePre.js
+++ b/src/components/Stripe/StripeAlumniSpousePre.js
@@ -22,7 +22,7 @@ class StripeAlumniSpousePre extends Component {
           panelLabel="Register"
           amount={15700}
           currency="USD"
-          stripeKey="pk_test_yFliojp5k9U6cxv0NRVL3W9U"
+          stripeKey="pk_test_mjnzkL9ebrh2Zbb5vy8hzniN"
           shippingAddress
           billingAddress={false}
           zipCode={false}


### PR DESCRIPTION
Adjust the tables and cells and add brighton high stripe info

### Before
<img width="920" alt="screen shot 2017-07-15 at 1 05 42 am" src="https://user-images.githubusercontent.com/8900638/28241910-a5bcc4bc-695b-11e7-85f9-6d5c9bcd5a4e.png">

### After
<img width="668" alt="screen shot 2017-07-15 at 12 43 09 pm" src="https://user-images.githubusercontent.com/8900638/28241911-a9c87bf0-695b-11e7-9833-2e1434437773.png">
